### PR TITLE
Add generalized Claude Code config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,33 @@
     - stow -t ~ tmux
     - stow -t ~ zshrc
     - stow -t ~ ghostty
+    - stow -t ~ claude  *(see cleanup below)*
+
+## Claude Code setup
+
+Before stowing `claude`, remove the files that will be replaced by symlinks:
+
+```bash
+# Remove commands being replaced (generalized versions now in dotfiles)
+rm ~/.claude/commands/{check,ship,review,sync,ralph,rebase-main}.md
+
+# Remove commands consolidated into review.md
+rm ~/.claude/commands/{review-pr,review-branch}.md
+
+# Remove commands that don't belong globally
+rm ~/.claude/commands/{fix-build,add-issue}.md
+
+# Remove stray directory
+rm -rf ~/.claude/commands/.claude/
+
+# Remove CLAUDE.md (replaced by symlink)
+rm ~/.claude/CLAUDE.md
+
+# Remove old dotfiles location
+rm ~/dotfiles/.claude/settings.local.json && rmdir ~/dotfiles/.claude
+
+# Stow
+cd ~/dotfiles && stow -t ~ claude
+```
+
+Files kept as-is in `~/.claude/commands/`: `ship-with-issue.md`, `gsd/`

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,0 +1,31 @@
+# User Preferences
+
+## Plans
+- Make the plan extremely concise. Sacrifice details for conciseness.
+- At the end of each plan, list any unanswered questions.
+
+## Git
+- When creating PRs, add labels: `bug` (fix), `enhancement` (feature/improvement), `upgrade` (dependency)
+- Use `gh pr edit <PR_NUMBER> --add-label "<label>"`
+
+## Commit Messages
+- If branch has an issue key (e.g. `PROJ-1234-fix-bug`), prefix: `PROJ-1234: Summary`
+- Otherwise just: `Summary`
+- Footer:
+  ```
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+
+## Testing Conventions
+**ALL tests MUST follow these rules — no exceptions.**
+
+### Naming
+- All test descriptions MUST start with `should`
+- `it('should return user when ID is valid')` ✓
+- `it('returns user when ID is valid')` ✗
+
+### Structure — AAA Pattern
+- Always use Arrange / Act / Assert with blank lines between sections
+- For complex tests (>5 lines of setup), add `// Arrange`, `// Act`, `// Assert` comments

--- a/claude/.claude/commands/check.md
+++ b/claude/.claude/commands/check.md
@@ -1,0 +1,16 @@
+---
+description: Run quality gates and fix issues without committing
+---
+
+# Check Command
+
+Run all quality gates for modified files. Auto-fix issues and retry. Does NOT commit or push.
+
+## Workflow
+
+1. Identify modified files (`git status --porcelain` + `git diff --name-only origin/main...HEAD`)
+2. Detect project tooling from config files (package.json scripts, build.gradle tasks, Makefile targets, Cargo.toml, pyproject.toml, go.mod, etc.) — read the config to find the actual commands
+3. Run quality gates in order: formatting/linting → type checking → unit tests
+4. If anything fails: auto-fix where possible, then re-run from step 3
+5. Stop after 3 failed fix attempts and report remaining problems
+6. Report: which checks ran, what was auto-fixed, final status

--- a/claude/.claude/commands/ralph.md
+++ b/claude/.claude/commands/ralph.md
@@ -1,0 +1,79 @@
+---
+description: "Interactive Ralph Wiggum loop setup"
+allowed-tools: ["AskUserQuestion", "Skill"]
+---
+
+# Interactive Ralph Loop Setup
+
+You MUST follow these steps IN ORDER. Do NOT skip ahead. Do NOT call the Skill tool until step 3.
+
+## Step 0: Check for arguments
+
+If `$ARGUMENTS` is non-empty, the user provided args inline (e.g. `/ralph Fix the auth bug`).
+In that case, use the provided text as the prompt and skip to Step 1 asking ONLY questions 2 and 3.
+
+If `$ARGUMENTS` is empty, proceed to Step 1 asking all 3 questions.
+
+## Step 1: Collect parameters (MANDATORY — do this FIRST)
+
+Call AskUserQuestion with the applicable questions in a single call:
+
+Question 1 (SKIP if `$ARGUMENTS` was provided):
+- question: "What should Ralph loop on?"
+- header: "Prompt"
+- multiSelect: false
+- options:
+  - label: "Fix all failing tests", description: "Run tests, fix failures, repeat until green"
+  - label: "Refactor and clean up", description: "Iteratively improve code quality"
+  - label: "Build a feature end-to-end", description: "Implement, test, and wire up a feature"
+
+Question 2:
+- question: "How many iterations max?"
+- header: "Iterations"
+- multiSelect: false
+- options:
+  - label: "15 (Recommended)", description: "Good for most tasks"
+  - label: "5", description: "Quick — small focused tasks"
+  - label: "30", description: "Long — complex multi-step work"
+  - label: "Unlimited", description: "No limit — runs until completion promise"
+
+Question 3:
+- question: "What completion message signals the task is done?"
+- header: "Completion"
+- multiSelect: false
+- options:
+  - label: "DONE (Recommended)", description: "Generic completion signal"
+  - label: "ALL TESTS PASSING", description: "For test-fixing loops"
+  - label: "FEATURE COMPLETE", description: "For feature implementation loops"
+
+## Step 2: Confirm before launching
+
+WAIT for the user's answers. Parse them:
+- Prompt = `$ARGUMENTS` if provided, otherwise answer to question 1. Strip " (Recommended)" suffix if present.
+- Max iterations = number from question 2. Strip " (Recommended)" suffix. If "Unlimited", will omit flag.
+- Completion message = answer to question 3. Strip " (Recommended)" suffix.
+
+Display a summary to the user (plain text, no tool call) and immediately proceed to step 3:
+
+```
+Launching Ralph loop:
+- Prompt: <prompt>
+- Max iterations: <N or unlimited>
+- Completion: <message>
+- Cancel anytime: /ralph-wiggum:cancel-ralph
+```
+
+## Step 3: Launch the loop
+
+Call the Skill tool:
+- skill: "ralph-wiggum:ralph-loop"
+- args: the assembled argument string
+
+Build the args string as follows:
+- Start with the prompt text
+- Append ` --max-iterations <N>` (omit entirely if Unlimited)
+- Append ` --completion-promise '<message>'`
+
+If the prompt contains special characters like quotes or dashes, wrap it in quotes in the args.
+
+NEVER call the Skill tool before you have answers from AskUserQuestion.

--- a/claude/.claude/commands/review-comments.md
+++ b/claude/.claude/commands/review-comments.md
@@ -1,0 +1,64 @@
+---
+description: Address PR review comments
+---
+
+# Review Comments Command
+
+Fetch unresolved review comments on the current PR, address each one, and push fixes.
+
+**Argument:** $ARGUMENTS
+
+## Workflow
+
+### Step 1: Identify PR
+
+If `$ARGUMENTS` is a PR number, use that. Otherwise detect from current branch:
+```bash
+gh pr view --json number,url
+```
+
+### Step 2: Fetch review comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.position != null) | {id, path, line: .original_line, body, in_reply_to_id}'
+```
+
+Also fetch top-level review comments:
+```bash
+gh pr view {number} --json reviews --jq '.reviews[] | select(.state != "APPROVED") | {author: .author.login, body}'
+```
+
+Filter to unresolved/actionable comments only.
+
+### Step 3: Address each comment
+
+For each comment:
+1. Read the referenced file and line
+2. Understand what the reviewer is asking
+3. If it's a valid fix: make the change
+4. If it's a question or disagreement: prepare a reply explaining the reasoning
+5. If unclear: skip and flag for user
+
+Group related comments on the same file together.
+
+### Step 4: Commit and push
+
+1. Stage all fixes with `git add`
+2. Commit with message: `Address review comments`
+3. Push with `git push`
+
+### Step 5: Reply to comments
+
+For each addressed comment, post a brief reply:
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{id}/replies -f body="Fixed."
+```
+
+For comments where you chose not to change code, reply with a short explanation.
+
+### Step 6: Report
+
+Summary:
+- Comments addressed with code changes
+- Comments replied to without code changes
+- Comments skipped (if any — explain why)

--- a/claude/.claude/commands/review.md
+++ b/claude/.claude/commands/review.md
@@ -1,0 +1,43 @@
+---
+description: Review branch or PR against style guidelines
+---
+
+# Review Command
+
+Review code as a colleague — professional but humble. Lead with strengths, frame issues as observations.
+
+**Argument:** $ARGUMENTS
+
+- If `$ARGUMENTS` is a PR number → review that PR and post a comment (`gh pr review N --comment`)
+- If empty → review current branch locally (output only, no comment posted)
+
+## Gather changes
+
+- PR mode: `gh pr diff $ARGUMENTS`
+- Branch mode: `git diff origin/main...HEAD` + `git diff HEAD` (uncommitted)
+
+## Review checklist
+
+Review against CLAUDE.md conventions and project-specific rules:
+
+1. **Testing** (CRITICAL): test names start with "should", AAA pattern, lean and focused
+2. **Simplicity**: simplest solution? unnecessary abstractions?
+3. **Safety**: incremental changes? unintended side effects? edge cases?
+4. **Clean code**: self-documenting? clear names? established patterns?
+5. **Language-specific**: check project CLAUDE.md for language rules
+
+## Output format
+
+```
+## Style Review
+
+**Summary**: [1-2 sentences — lead with what's working]
+**Strengths**: [specific and genuine]
+**Observations**:
+- [Critical]: ...
+- [Suggestion]: ...
+- [Minor]: ...
+**Safety Assessment**: [incremental and safe?]
+```
+
+Do NOT approve or request changes on PRs — only comment. Be specific with file paths and line numbers.

--- a/claude/.claude/commands/ship.md
+++ b/claude/.claude/commands/ship.md
@@ -1,0 +1,39 @@
+---
+description: Commit changes and create/update PR
+---
+
+# Ship Command
+
+Commit code and create/update PR. Run `/check` first — this command does not run quality gates.
+
+Execute all steps automatically without asking for permission between steps.
+
+## Step 1: Ensure feature branch
+
+If on `main`/`master`: ask user for a branch name, create and switch to it.
+
+## Step 2: Sync with main
+
+Run `/sync` to rebase on latest main.
+
+## Step 3: Commit
+
+1. Review changes (`git status`, `git diff`)
+2. Extract issue key from branch name if present (e.g. `PROJ-1234` from `PROJ-1234-fix-bug`)
+3. Stage and commit per the commit message format in CLAUDE.md
+
+## Step 4: Squash if needed
+
+If more than 1 commit on the branch, squash using merge-base:
+```bash
+MERGE_BASE=$(git merge-base origin/main HEAD)
+git reset --soft $MERGE_BASE
+git commit -m "[message]"
+```
+**Never use `git reset --soft origin/main`** — it may include unrelated commits.
+
+## Step 5: Push and manage PR
+
+- If PR exists: `git push --force-with-lease`
+- If no PR: `git push -u origin HEAD` then `gh pr create --draft` with summary and test plan
+- Add labels per CLAUDE.md conventions (`bug`/`enhancement`/`upgrade`)

--- a/claude/.claude/commands/sync.md
+++ b/claude/.claude/commands/sync.md
@@ -1,0 +1,14 @@
+---
+description: Fetch and rebase on main (no quality gates)
+---
+
+# Sync Command
+
+Fetch latest main, rebase current branch, push. No quality gates.
+
+1. Stash uncommitted changes if any (`git stash push -m "sync-stash"`)
+2. `git fetch origin main && git rebase origin/main`
+3. If conflicts: resolve, `git add`, `git rebase --continue`. Abort if too complex.
+4. `git push --force-with-lease`
+5. Restore stash if created (`git stash pop`)
+6. Report: commits rebased, conflicts resolved, push status


### PR DESCRIPTION
## Summary
- Add Claude Code commands and CLAUDE.md to dotfiles with stow support (`stow -t ~ claude`)
- Generalize check/ship/rebase-main/review commands to work across any project (no hardcoded tooling, Jira, or NEX patterns)
- Consolidate 3 review commands (review, review-pr, review-branch) into 1
- Remove project-specific commands (fix-build, add-issue)

## Test plan
- [ ] Run cleanup commands from README to remove old files
- [ ] `cd ~/dotfiles && stow -t ~ claude`
- [ ] Verify `readlink ~/.claude/CLAUDE.md` points to dotfiles
- [ ] Open new Claude Code session, run `/sync` and `/review` to confirm