### PR TITLE
PR fixer: auto-rebase conflicting PRs with force-with-lease

### DIFF
--- a/claude/.claude/skills/_pr-shared/fix-one-pr.md
+++ b/claude/.claude/skills/_pr-shared/fix-one-pr.md
@@ -15,8 +15,12 @@ returns a compact result. Inputs: `repo` (owner/name), `number`, `branch`, `url`
    ```
    Work entirely inside `$wt`. The branch must track `origin/<branch>` so pushes land on the PR.
 
-2. **Run the fixer engine** against `$wt` — `~/.claude/skills/_pr-shared/fixer-engine.md`, Steps A–G,
-   for PR `<number>`. Push with `git push origin <branch>`. Two binding overrides for fan-out:
+2. **Run the fixer engine** against `$wt` — `~/.claude/skills/_pr-shared/fixer-engine.md`, Steps 0
+   then A–G, for PR `<number>`. Three binding overrides for fan-out:
+   - **Rebase (engine 0).** Run `rebase-onto-base.sh rebase "$wt" <branch>`. Exit 1 → skip on. Exit 0
+     (clean) → `rebase-onto-base.sh push "$wt" <branch>`. Exit 3 (conflicts) → resolve, `git rebase
+     --continue`, run the project's build/tests in `$wt`: green → `rebase-onto-base.sh push "$wt"
+     <branch>`; red → `git rebase --abort`, push nothing, record the conflict in `deferred`.
    - **Non-interactive.** There is no user to ask. **Auto-fix only low-risk** (lint/format, trivial
      build errors — missing imports, typos, unused vars). **Skip high-risk** (test failures, coverage
      gaps, security findings, non-trivial logic/build) — do NOT attempt them, do NOT block; record
@@ -47,7 +51,9 @@ returns a compact result. Inputs: `repo` (owner/name), `number`, `branch`, `url`
 }
 ```
 
-- `status:"nothing-to-do"` when a fresh pass finds no failing checks and no actionable threads.
+- A rebase goes in `changes` (e.g. "rebased onto main, force-pushed with lease"); a conflict that
+  failed the build/test gate goes in `deferred`.
+- `status:"nothing-to-do"` when a fresh pass finds no conflicts, no failing checks, and no actionable threads.
 - `status:"partial"` when something was fixed but `deferred` or `needsMe` is non-empty.
 - On `error` (worktree/fetch failed, push rejected), set `status:"error"`, put the reason in
   `needsMe`, push nothing.

--- a/claude/.claude/skills/_pr-shared/fixer-engine.md
+++ b/claude/.claude/skills/_pr-shared/fixer-engine.md
@@ -4,6 +4,22 @@ The mechanics shared by `my-pr-fixer` (interactive, one PR) and `fix-one-pr.md` 
 per PR). The caller identifies the PR (`number`, `owner`, `repo`) and sets how high-risk work and
 pushes are handled; this engine is the how. Token-lean throughout: read only what you'll act on.
 
+## 0. Rebase onto the base branch when the PR conflicts
+
+A conflicting branch can't merge no matter how green CI is. The deterministic git plumbing lives in
+`~/.claude/skills/_pr-shared/rebase-onto-base.sh` — it owns every force-push (always `--force-with-lease`):
+```bash
+rebase-onto-base.sh rebase <worktree> <branch> [base]   # 0=clean (not pushed) · 1=nothing to do · 3=conflicts left in tree
+```
+- **Exit 1** → branch is current, skip to Step A.
+- **Exit 0** (clean rebase) → run nothing extra; force-push via `rebase-onto-base.sh push <worktree> <branch>`.
+- **Exit 3** (conflicts in the tree) → resolve them, `git rebase --continue`, then run the project's
+  build/tests in the worktree as a gate. **Green** → `rebase-onto-base.sh push <worktree> <branch>`.
+  **Red** → `git rebase --abort`, push nothing. The caller decides who resolves: interactive asks
+  first; fan-out auto-resolves and defers when the gate is red.
+
+Never type a raw `git push --force` — the script is the only thing that force-pushes, always with lease.
+
 ## A. Fix CI / pipeline failures
 
 Pull **failing** checks only — never dump the green list:
@@ -47,7 +63,9 @@ Read the referenced file + context, then decide **does it make sense to address?
 
 If code changed: run `/precheck`; stage and commit with the branch issue-key prefix
 (`PROJ-1234: Address review comments`) — no key, stop and ask for a rename; group related fixes into
-one commit. Then push per the caller's rule. **Never force-push.**
+one commit. Then push per the caller's rule: `git push origin <branch>` for normal pushes, or
+`rebase-onto-base.sh push <worktree> <branch>` when a Step 0 rebase rewrote history. **Never type a
+raw `git push --force`.**
 
 ## E. Answer every in-scope thread (only after a successful push)
 
@@ -81,7 +99,7 @@ saw. The caller decides whether to wait for them:
 - **Never modify CI config** to go green — fix the actual code.
 - **Never weaken a test** — a failing test usually means the code is wrong.
 - **Reply only after a successful push** — never claim "Fixed" before the push lands.
-- **Never force-push; never dismiss reviews.**
+- **Force-push only with `--force-with-lease`, only after a Step 0 rebase; never plain `--force`, never dismiss reviews.**
 - **Group related fixes into one commit** — not one per comment.
 - **Bots review as `COMMENTED`** — don't filter top-level reviews on `CHANGES_REQUESTED` alone.
 - **Answer every actionable thread before finishing** — an unresolved bot thread with no reply is a

--- a/claude/.claude/skills/_pr-shared/list-my-fixable-prs.sh
+++ b/claude/.claude/skills/_pr-shared/list-my-fixable-prs.sh
@@ -21,18 +21,21 @@ done
 limit="${limit:-50}"
 me=$(gh api user --jq .login)
 
-# A PR is fixable when the latest commit's check rollup is FAILURE/ERROR, OR some
-# unresolved thread's last comment isn't mine (an actionable reply I still owe).
+# A PR is fixable when the latest commit's check rollup is FAILURE/ERROR, OR it
+# conflicts with its base (needs a rebase), OR some unresolved thread's last
+# comment isn't mine (an actionable reply I still owe).
 PRED='select(.isDraft | not)
   | select(
       (.commits.nodes[0].commit.statusCheckRollup.state | IN("FAILURE","ERROR"))
+      or
+      (.mergeable == "CONFLICTING")
       or
       ([.reviewThreads.nodes[]
         | select(.isResolved | not)
         | select((.comments.nodes | last | .author.login) != $ME)] | length > 0)
     )'
 
-PR_FIELDS='number url title isDraft headRefName headRefOid
+PR_FIELDS='number url title isDraft headRefName headRefOid mergeable
   repository{ nameWithOwner isArchived }
   commits(last:1){ nodes{ commit{ statusCheckRollup{ state } } } }
   reviewThreads(first:50){ nodes{ isResolved comments(first:50){ nodes{ author{ login } } } } }'

--- a/claude/.claude/skills/_pr-shared/rebase-onto-base.sh
+++ b/claude/.claude/skills/_pr-shared/rebase-onto-base.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Deterministic rebase plumbing for the PR fixers. Owns every force-push so no
+# caller ever types a raw `git push --force` — it's always `--force-with-lease`.
+# Conflict resolution and the build/test gate are the caller's job, NOT this script's.
+#
+#   rebase-onto-base.sh rebase <worktree> <branch> [base]
+#     0  clean rebase applied (NOT pushed — caller runs `push` after its gate)
+#     1  nothing to do (branch already contains base tip)
+#     3  conflicts — left in the working tree for the caller to resolve or abort
+#
+#   rebase-onto-base.sh push <worktree> <branch>
+#     force-pushes with lease (the ONLY force-push in the fixer flow)
+set -euo pipefail
+
+cmd="${1:-}"; wt="${2:-}"; branch="${3:-}"
+[ -n "$cmd" ] && [ -n "$wt" ] && [ -n "$branch" ] || { echo "usage: rebase-onto-base.sh rebase|push <worktree> <branch> [base]" >&2; exit 2; }
+g(){ git -C "$wt" "$@"; }
+
+case "$cmd" in
+  push)
+    g push --force-with-lease origin "$branch"
+    ;;
+
+  rebase)
+    base="${4:-}"
+    [ -n "$base" ] || base=$(g symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+    [ -n "$base" ] || { echo "cannot determine base branch; pass it explicitly" >&2; exit 2; }
+
+    g fetch -q origin "$base"
+    [ "$(g rev-list --count "HEAD..origin/$base")" -eq 0 ] && exit 1
+
+    if g rebase "origin/$base"; then
+      exit 0
+    fi
+    exit 3   # conflicts left in tree on purpose — caller resolves + gates, or `git rebase --abort`
+    ;;
+
+  *)
+    echo "unknown command: $cmd" >&2; exit 2 ;;
+esac

--- a/claude/.claude/skills/my-pr-fixer-all/SKILL.md
+++ b/claude/.claude/skills/my-pr-fixer-all/SKILL.md
@@ -62,8 +62,9 @@ One compact block per PR, in this exact shape — no tables, no per-file rundown
   gets its own worktree under `platform.worktrees/`, removed when done (see [[worktree-per-task]]).
 - **Skip and report, don't guess.** A PR whose worktree/fetch/push fails is `status:"error"` and
   goes on the needs-me list. Never half-push.
-- **Never force-push, never weaken tests, never edit CI to go green** — these carry through from
-  `my-pr-fixer`; the agents inherit them.
-- The list script only surfaces PRs with a real problem, so reruns resume cleanly — a PR with no
-  failing check and no actionable thread won't reappear.
+- **Never weaken tests, never edit CI to go green** — these carry through from `my-pr-fixer`; the
+  agents inherit them. **Force-push only with `--force-with-lease`, only after a Step 0 rebase** —
+  clean rebase auto-pushes; a conflict that fails the worktree build/test gate is deferred, not pushed.
+- The list script only surfaces PRs with a real problem, so reruns resume cleanly — a PR that's
+  mergeable with no failing check and no actionable thread won't reappear.
 - **`--dry-run`** evaluates and reports but changes nothing. Recommend it for the first org run.

--- a/claude/.claude/skills/my-pr-fixer/SKILL.md
+++ b/claude/.claude/skills/my-pr-fixer/SKILL.md
@@ -16,9 +16,12 @@ thread. Replies read as mine: plain, humble, no agent tells.
 ## Workflow
 
 1. **Identify the PR.** If `$ARGUMENTS` is a number, use it; else `gh pr view --json number,title,headRefName,url`.
-2. **Run the fixer engine** — `~/.claude/skills/_pr-shared/fixer-engine.md`, Steps A–G, against this
-   PR on the current branch. Push with `git push origin <branch>` (never force-push). Two
-   interactive points specific to this skill:
+2. **Run the fixer engine** — `~/.claude/skills/_pr-shared/fixer-engine.md`, Steps 0 then A–G,
+   against this PR on the current branch. Push with `git push origin <branch>`, or
+   `rebase-onto-base.sh push <worktree> <branch>` after a Step 0 rebase. Interactive points specific
+   to this skill:
+   - **Rebase (engine 0):** a clean rebase is automatic; if it hits conflicts, show me the
+     conflicting files and **wait for my confirmation** before resolving and force-pushing.
    - **CI fixes (engine A):** fix low-risk automatically; for high-risk (test failures, coverage,
      security, non-trivial build/logic) show what failed, the root cause, and the proposed fix, then
      **wait for my confirmation** before touching it.
@@ -28,8 +31,9 @@ thread. Replies read as mine: plain, humble, no agent tells.
 
 ## Important rules
 
-Engine rules apply (no CI edits, no weakened tests, reply only after push, no force-push, group
-fixes, answer every actionable thread, loop until a clean pass). On top of those:
+Engine rules apply (no CI edits, no weakened tests, reply only after push, force-push only with
+`--force-with-lease` after a rebase, group fixes, answer every actionable thread, loop until a clean
+pass). On top of those:
 
 - **Decline, don't block.** Address every comment that makes sense; for the rest, reply with the
   reason. Only leave a thread for me when it genuinely needs my decision — say so in the reply.


### PR DESCRIPTION
## Problem
My PR fixer skills never handled merge conflicts — a PR conflicting with its base stayed invisible (the list script only surfaced failing CI or open threads) and the engine never rebased, so I had to rebase those by hand.

## Solution
Add `rebase-onto-base.sh` that owns every force-push (always `--force-with-lease`, never raw `--force`). Surface `CONFLICTING` PRs in the list script. Wire engine Step 0: a clean rebase auto-pushes; conflicts get resolved behind a local build/test gate (green → push, red → abort + defer). Interactive fixer asks before resolving; fan-out auto-resolves.

## Test plan
- [x] Smoke-tested `rebase-onto-base.sh` exit codes (0 clean / 1 nothing / 3 conflict / 2 usage) on a throwaway repo
- [x] `list-my-fixable-prs.sh` syntax-checked and run against the org

Risk: **Low** — personal skill/docs only, no app code; force-push is lease-guarded and gated; trivially revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)